### PR TITLE
Remove z plane reduction for reference image

### DIFF
--- a/bin/starfishDriver.py
+++ b/bin/starfishDriver.py
@@ -527,12 +527,12 @@ def run(
 
         ref_img = None
         if use_ref:
-            ref_img = img.reduce({Axes.CH, Axes.ROUND, Axes.ZPLANE}, func="max")
+            ref_img = img.reduce({Axes.CH, Axes.ROUND}, func="max")
         if anchor_name:
             ref_img = (
                 experiment[fov]
                 .get_image(anchor_name)
-                .reduce({Axes.CH, Axes.ROUND, Axes.ZPLANE}, func="max")
+                .reduce({Axes.CH, Axes.ROUND}, func="max")
             )
 
         if rescale:

--- a/bin/starfishDriver.py
+++ b/bin/starfishDriver.py
@@ -530,9 +530,7 @@ def run(
             ref_img = img.reduce({Axes.CH, Axes.ROUND}, func="max")
         if anchor_name:
             ref_img = (
-                experiment[fov]
-                .get_image(anchor_name)
-                .reduce({Axes.CH, Axes.ROUND}, func="max")
+                experiment[fov].get_image(anchor_name).reduce({Axes.CH, Axes.ROUND}, func="max")
             )
 
         if rescale:


### PR DESCRIPTION
We shouldn't be reducing the z axis to a single plane for reference image analysis, just the round and channel axis. This allows 3d reference images to be used.