### PR TITLE
Fix to how physical coordinates are set when conversion to spacetx

### DIFF
--- a/bin/spaceTxConverter.py
+++ b/bin/spaceTxConverter.py
@@ -111,15 +111,19 @@ class FISHTile(FetchedTile):
             return {
                 Coordinates.X: (
                     self.locs[Axes.X] * self.voxel[Axes.X],
-                    (self.locs[Axes.X] + self.img_shape[Axes.X]) * self.voxel[Axes.X],
+                    (self.locs[Axes.X] + self.img_shape[Axes.X]) * self.voxel[Axes.X]
+                    - self.voxel[Axes.X],
                 ),
                 Coordinates.Y: (
                     self.locs[Axes.Y] * self.voxel[Axes.Y],
-                    (self.locs[Axes.Y] + self.img_shape[Axes.Y]) * self.voxel[Axes.Y],
+                    (self.locs[Axes.Y] + self.img_shape[Axes.Y]) * self.voxel[Axes.Y]
+                    - self.voxel[Axes.Y],
                 ),
                 Coordinates.Z: (
-                    (self.locs[Axes.ZPLANE] + self._zplane) * self.voxel[Axes.ZPLANE],
-                    (self.locs[Axes.ZPLANE] + self._zplane + 1) * self.voxel[Axes.ZPLANE],
+                    self.locs[Axes.ZPLANE] * self.voxel[Axes.ZPLANE],
+                    (self.locs[Axes.ZPLANE] + self.img_shape[Axes.ZPLANE])
+                    * self.voxel[Axes.ZPLANE]
+                    - self.voxel[Axes.ZPLANE],
                 ),
             }
         else:


### PR DESCRIPTION
Currently, if an image with pixel size 1000x1000 and with the x and y physical sizes set to 1, the physical distance values end up being:
`0. , 1.001001, 2.002002, 3.003003, 4.004004, 5.00500501, 6.00600601, 7.00700701, ..., 1000`
This is because the max value ends up in the range and it increases the step size slightly so that it still has the correct number of values. With this change, and image with the previous characteristic will have physical distance values of:
`0, 1., 2., 3., 4., 5., 6., 7., ... 999.`
Or if the x and y physical distances are set to 50:
`0, 50., 100., 150., 200., 250., ..., 49950.`
Which reflect what we expect the physical distance values to be.