### PR TITLE
Add option for single round aux images

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.7.0
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black"]

--- a/bin/imgProcessing.py
+++ b/bin/imgProcessing.py
@@ -437,8 +437,10 @@ def cli(
         if aux_name:
             # If registration image is given calculate registration shifts for each image and apply them
             register = exp[fov].get_image(aux_name)
-            if register.shape['r'] != img.shape['r']:
-                raise Exception('In order to register auxillary images to each other, auxillary images must have same dimension as primary image')
+            if register.shape["r"] != img.shape["r"]:
+                raise Exception(
+                    "In order to register auxillary images to each other, auxillary images must have same dimension as primary image"
+                )
             else:
                 print("\taligning to " + aux_name)
                 img = register_primary(img, register, ch_per_reg)

--- a/bin/imgProcessing.py
+++ b/bin/imgProcessing.py
@@ -437,8 +437,11 @@ def cli(
         if aux_name:
             # If registration image is given calculate registration shifts for each image and apply them
             register = exp[fov].get_image(aux_name)
-            print("\taligning to " + aux_name)
-            img = register_primary(img, register, ch_per_reg)
+            if register.shape['r'] != img.shape['r']:
+                raise Exception('In order to register auxillary images to each other, auxillary images must have same dimension as primary image')
+            else:
+                print("\taligning to " + aux_name)
+                img = register_primary(img, register, ch_per_reg)
 
         if not rescale and not (clip_min == 0 and clip_max == 0):
             print("\tclip and scaling...")

--- a/bin/spaceTxConverter.py
+++ b/bin/spaceTxConverter.py
@@ -896,13 +896,14 @@ if __name__ == "__main__":
     args = p.parse_args()
 
     # Sub in default values for aux_channel_count, aux_channel_slope, and aux_channel_intercept
-    # if they are not specified in the input
-    if not args.aux_channel_count:
-        args.aux_channel_count = [0] * len(args.aux_names)
-    if not args.aux_channel_slope:
-        args.aux_channel_slope = [1] * len(args.aux_names)
-    if not args.aux_channel_intercept:
-        args.aux_channel_intercept = [1] * len(args.aux_names)
+    # if they are not specified in the input (only if single_round_aux is specified)
+    if args.single_round_aux:
+        if not args.aux_channel_count:
+            args.aux_channel_count = [0] * len(args.aux_names)
+        if not args.aux_channel_slope:
+            args.aux_channel_slope = [1] * len(args.aux_names)
+        if not args.aux_channel_intercept:
+            args.aux_channel_intercept = [1] * len(args.aux_names)
 
     aux_lens = []
     aux_vars = [

--- a/bin/spaceTxConverter.py
+++ b/bin/spaceTxConverter.py
@@ -577,8 +577,8 @@ def cli(
 
     os.makedirs(output_dir, exist_ok=True)
 
-    #reportFile = os.path.join(output_dir, datetime.now().strftime("%Y%m%d_%H%M_TXconversion.log"))
-    #sys.stdout = open(reportFile, "w")
+    reportFile = os.path.join(output_dir, datetime.now().strftime("%Y%m%d_%H%M_TXconversion.log"))
+    sys.stdout = open(reportFile, "w")
 
     image_dimensions: Mapping[Union[str, Axes], int] = {
         Axes.ROUND: counts["rounds"],
@@ -673,7 +673,7 @@ def cli(
     print("Elapsed time for .json manipulation", t2 - t1)
     print("Operation complete, total elapsed time", t2 - t0)
 
-    #sys.stdout = sys.__stdout__
+    sys.stdout = sys.__stdout__
     return 0
 
 
@@ -892,7 +892,6 @@ if __name__ == "__main__":
     p.add_argument("--z-pos-voxel", type=float, nargs="?")
     p.add_argument("--add-blanks", dest="add_blanks", action="store_true")
     p.set_defaults(add_blanks=False)
-
 
     args = p.parse_args()
 

--- a/input_schemas/spaceTxConversion.json
+++ b/input_schemas/spaceTxConversion.json
@@ -17,6 +17,7 @@
 				"aux_file_formats?",
 				"aux_file_vars?",
 				"aux_cache_read_order?",
+				"aux_single_round?",
 				"aux_channel_count?",
 				"aux_channel_slope?",
 				"aux_channel_intercept?"

--- a/pipeline.cwl
+++ b/pipeline.cwl
@@ -137,6 +137,9 @@ inputs:
         aux_cache_read_order:
           type: string[]?
           doc: Order of non x,y dimensions within each image. One entry per aux_name, with semicolon-delimited vars.
+        aux_single_round:
+          type: string[]?
+          doc: If True, the specified aux view will only have one round.
         aux_channel_count:
           type: float[]?
           doc: Count of channels in each aux image.

--- a/steps/inputParser.cwl
+++ b/steps/inputParser.cwl
@@ -35,6 +35,7 @@ outputs:
   aux_tilesets_aux_file_formats: string[]
   aux_tilesets_aux_file_vars: string[]
   aux_tilesets_aux_cache_read_order: string[]
+  aux_tilesets_aux_single_round: string[]
   aux_tilesets_aux_channel_count: float[]
   aux_tilesets_aux_channel_slope: float[]
   aux_tilesets_aux_channel_intercept: int[]

--- a/steps/spaceTxConversion.cwl
+++ b/steps/spaceTxConversion.cwl
@@ -107,6 +107,9 @@ inputs:
         aux_cache_read_order:
           type: string[]?
           doc: Order of non x,y dimensions within each image. One entry per aux_name, with semicolon-delimited vars.
+        aux_single_round:
+          type: string[]?
+          doc: If True, aux view will only be a single round.
         aux_channel_count:
           type: int[]?
           doc: Count of channels in each aux image
@@ -202,7 +205,7 @@ steps:
     in:
       datafile: parameter_json
       schema: read_schema/data
-    out: [round_count, zplane_count, channel_count, fov_count, round_offset, fov_offset, zplane_offset, channel_offset, file_format, file_vars, cache_read_order, aux_tilesets_aux_names, aux_tilesets_aux_file_formats, aux_tilesets_aux_file_vars, aux_tilesets_aux_cache_read_order, aux_tilesets_aux_channel_count, aux_tilesets_aux_channel_slope, aux_tilesets_aux_channel_intercept,  fov_positioning_x_locs, fov_positioning_x_shape, fov_positioning_x_voxel, fov_positioning_y_locs, fov_positioning_y_shape, fov_positioning_y_voxel, fov_positioning_z_locs, fov_positioning_z_shape, fov_positioning_z_voxel, add_blanks]
+    out: [round_count, zplane_count, channel_count, fov_count, round_offset, fov_offset, zplane_offset, channel_offset, file_format, file_vars, cache_read_order, aux_tilesets_aux_names, aux_tilesets_aux_file_formats, aux_tilesets_aux_file_vars, aux_tilesets_aux_cache_read_order, aux_tilesets_aux_single_round, aux_tilesets_aux_channel_count, aux_tilesets_aux_channel_slope, aux_tilesets_aux_channel_intercept,  fov_positioning_x_locs, fov_positioning_x_shape, fov_positioning_x_voxel, fov_positioning_y_locs, fov_positioning_y_shape, fov_positioning_y_voxel, fov_positioning_z_locs, fov_positioning_z_shape, fov_positioning_z_voxel, add_blanks]
     when: $(inputs.datafile != null)
 
   execute_conversion:
@@ -317,6 +320,10 @@ steps:
                 type: string[]?
                 inputBinding:
                   prefix: --aux-cache-read-order
+              aux_single_round:
+                type: string[]?
+                inputBinding:
+                  prefix: --aux-single-round
               aux_channel_count:
                 type: int[]?
                 inputBinding:
@@ -432,7 +439,7 @@ steps:
         source: [stage_conversion/cache_read_order, cache_read_order]
         pickValue: first_non_null
       aux_tilesets:
-        source: [aux_tilesets, stage_conversion/aux_tilesets_aux_names, stage_conversion/aux_tilesets_aux_file_formats, stage_conversion/aux_tilesets_aux_file_vars, stage_conversion/aux_tilesets_aux_cache_read_order, stage_conversion/aux_tilesets_aux_channel_count, stage_conversion/aux_tilesets_aux_channel_slope, stage_conversion/aux_tilesets_aux_channel_intercept]
+        source: [aux_tilesets, stage_conversion/aux_tilesets_aux_names, stage_conversion/aux_tilesets_aux_file_formats, stage_conversion/aux_tilesets_aux_file_vars, stage_conversion/aux_tilesets_aux_cache_read_order, stage_conversion/aux_tilesets_aux_single_round, stage_conversion/aux_tilesets_aux_channel_count, stage_conversion/aux_tilesets_aux_channel_slope, stage_conversion/aux_tilesets_aux_channel_intercept]
         valueFrom: |
           ${
             if(!self[1]){
@@ -443,9 +450,10 @@ steps:
                 aux_file_formats: self[2],
                 aux_file_vars: self[3],
                 aux_cache_read_order: self[4],
-                aux_channel_count: self[5],
-                aux_channel_slope: self[6],
-                aux_channel_intercept: self[7]
+                aux_single_round: self[5]
+                aux_channel_count: self[6],
+                aux_channel_slope: self[7],
+                aux_channel_intercept: self[8]
               };
             };
           }


### PR DESCRIPTION
Adds ```--singe-round-aux``` parameter that prevents the aux images from being duplicated if there is only a single aux image per FOV.