### PR TITLE
Add new registration option

### DIFF
--- a/bin/imgProcessing.py
+++ b/bin/imgProcessing.py
@@ -26,6 +26,7 @@ from skimage.registration import phase_cross_correlation
 from starfish import Experiment, ImageStack
 from starfish.types import Levels
 from tqdm import tqdm
+import pdb
 
 
 def saveImg(loc: str, prefix: str, img: ImageStack):
@@ -91,11 +92,14 @@ def saveExp(
                 print(f"\tcopied {file}")
 
 
-def register_primary(img, reg_img, chs_per_reg):
+def register_primary_aux(img, reg_img, chs_per_reg):
     """
     Register primary images using provided registration images.
     chs_per_reg is number of primary image channels
     associated with each registration image.
+
+    Calculates shifts between auxillary images using the first
+    auxillary image as a reference, then applies shifts to primary images.
     """
     # Calculate registration shifts from registration images
     shifts = {}
@@ -124,6 +128,44 @@ def register_primary(img, reg_img, chs_per_reg):
             img.xarray.data[r, ch] = ndimage.affine_transform(
                 img.xarray.data[r, ch],
                 np.linalg.inv(tforms[(r, ch // chs_per_reg)]),
+                output_shape=shape[2:],
+            )
+    return img
+
+
+def register_primary_primary(img, reg_img):
+    """
+    Register primary images using provided registration images.
+
+    Calculates shifts between primary images and the single auxillary image
+    and then applies shifts to primary images.
+    """
+
+    # Calculate shifts from each primary image to the registration image
+    shifts = {}
+    for r in range(img.num_rounds):
+        for ch in range(img.num_chs):
+            shift, error, diffphase = phase_cross_correlation(
+                reg_img.xarray.data[0, 0], img.xarray.data[r, ch], upsample_factor=100
+            )
+            shifts[(r, ch)] = shift
+
+    # Create transformation matrices
+    shape = img.raw_shape
+    tforms = {}
+    for r, ch in shifts:
+        tform = np.diag([1.0] * 4)
+        # Start from 1 because we don't want to shift in the z direction (if there is one)
+        for i in range(1, 3):
+            tform[i, 3] = shifts[(r, ch)][i]
+        tforms[(r, ch)] = tform
+
+    # Register primary images
+    for r in range(img.num_rounds):
+        for ch in range(img.num_chs):
+            img.xarray.data[r, ch] = ndimage.affine_transform(
+                img.xarray.data[r, ch],
+                np.linalg.inv(tforms[(r, ch)]),
                 output_shape=shape[2:],
             )
     return img
@@ -259,7 +301,8 @@ def cli(
     clip_max: float = 99.9,
     level_method: str = "",
     is_volume: bool = False,
-    aux_name: str = None,
+    register_aux_view: str = None,
+    register_primary_view: str = None,
     ch_per_reg: int = 1,
     background_name: str = None,
     register_background: bool = False,
@@ -345,7 +388,6 @@ def cli(
         level_method = Levels.SCALE_BY_IMAGE
 
     t0 = time()
-
     exp = starfish.core.experiment.experiment.Experiment.from_json(
         str(input_dir / "experiment.json")
     )
@@ -434,16 +476,27 @@ def cli(
                 print("\tapplying histogram matching to anchor image...")
                 anchor = match_hist_2_min(anchor)
 
-        if aux_name:
-            # If registration image is given calculate registration shifts for each image and apply them
-            register = exp[fov].get_image(aux_name)
+        if register_aux_view:
+            # If register_aux_view calculate registration shifts between specified aux images and apply to primary images
+            register = exp[fov].get_image(register_aux_view)
             if register.shape["r"] != img.shape["r"]:
                 raise Exception(
-                    "In order to register auxillary images to each other, auxillary images must have same dimension as primary image"
+                    "If --register-aux-view is used, auxillary image dimensions must match primary image dimensions"
                 )
             else:
-                print("\taligning to " + aux_name)
-                img = register_primary(img, register, ch_per_reg)
+                print("\taligning to " + register_aux_view)
+                img = register_primary_aux(img, register, ch_per_reg)
+
+        if register_primary_view:
+            # If register_primary_view calculate registration shifts between primary images and the single aux image and apply to primary images
+            register = exp[fov].get_image(register_primary_view)
+            if register.shape["r"] != 1:
+                raise Exception(
+                    "If --register-primary-view is used, auxillary images must have only a single round/channel (use the --single-round-aux option)"
+                )
+            else:
+                print("\taligning to " + register_primary_view)
+                img = register_primary_primary(img, register)
 
         if not rescale and not (clip_min == 0 and clip_max == 0):
             print("\tclip and scaling...")
@@ -461,6 +514,11 @@ def cli(
 
         else:
             print("\tskipping clip and scale.")
+            # Clip values below 0 and greater than 1 (prevents errors in decoding)
+            clip = starfish.image.Filter.ClipPercentileToZero(
+                p_min=0, p_max=100, is_volume=is_volume, level_method=Levels.CLIP
+            )
+            clip.run(img, in_place=True)
 
         print(f"\tView {fov} complete")
         # save modified image
@@ -492,6 +550,7 @@ if __name__ == "__main__":
     p.add_argument("--level-method", type=str, nargs="?")
     p.add_argument("--is-volume", dest="is_volume", action="store_true")
     p.add_argument("--register-aux-view", type=str, nargs="?")
+    p.add_argument("--register-primary-view", type=str, nargs="?")
     p.add_argument("--ch-per-reg", type=int, nargs="?")
     p.add_argument("--background-view", type=str, nargs="?")
     p.add_argument("--register-background", dest="register_background", action="store_true")
@@ -520,6 +579,12 @@ if __name__ == "__main__":
         except Exception:
             n_processes = 1
 
+    # Raise exception if both register-aux-view and register-primary-view are used
+    if args.register_aux_view and args.register_primary_view:
+        raise Exception(
+            "register-aux-view and register-primary-view options are mutually exclusive. Choose one."
+        )
+
     cli(
         input_dir=args.input_dir,
         output_dir=output_dir,
@@ -527,7 +592,8 @@ if __name__ == "__main__":
         clip_max=args.clip_max,
         level_method=args.level_method,
         is_volume=args.is_volume,
-        aux_name=args.register_aux_view,
+        register_aux_view=args.register_aux_view,
+        register_primary_view=args.register_primary_view,
         ch_per_reg=args.ch_per_reg,
         background_name=args.background_view,
         register_background=args.register_background,

--- a/bin/imgProcessing.py
+++ b/bin/imgProcessing.py
@@ -26,7 +26,6 @@ from skimage.registration import phase_cross_correlation
 from starfish import Experiment, ImageStack
 from starfish.types import Levels
 from tqdm import tqdm
-import pdb
 
 
 def saveImg(loc: str, prefix: str, img: ImageStack):
@@ -488,11 +487,12 @@ def cli(
                 img = register_primary_aux(img, register, ch_per_reg)
 
         if register_primary_view:
-            # If register_primary_view calculate registration shifts between primary images and the single aux image and apply to primary images
+            # If register_primary_view calculate registration shifts between primary images and the single aux image and
+            # apply to primary images
             register = exp[fov].get_image(register_primary_view)
             if register.shape["r"] != 1:
                 raise Exception(
-                    "If --register-primary-view is used, auxillary images must have only a single round/channel (use the --single-round-aux option)"
+                    "If --register-primary-view is used, auxillary images must have only a single round/channel (use the --aux-single-round option)"
                 )
             else:
                 print("\taligning to " + register_primary_view)

--- a/input_schemas/processing.json
+++ b/input_schemas/processing.json
@@ -6,6 +6,7 @@
 	"rescale?",
 	"is_volume?",
 	"register_aux_view?",
+	"register_to_primary?",
 	"channels_per_reg?",
 	"background_view?",
 	"register_background?",

--- a/pipeline.cwl
+++ b/pipeline.cwl
@@ -220,6 +220,10 @@ inputs:
     type: string?
     doc: The name of the auxillary view to be used for image registration.
 
+  register_to_primary:
+    type: boolean?
+    doc: If true, registration will be performed between the first round of register_aux_view and the primary view.
+
   background_view:
     type: string?
     doc: The name of the auxillary view to be used for background subtraction.  Background will be estimated if not provided.
@@ -989,6 +993,7 @@ steps:
       level_method: level_method
       is_volume: is_volume
       register_aux_view: register_aux_view
+      register_to_primary: register_to_primary
       channels_per_reg:
         source: [stagedSorted/aux_names, stagedSorted/aux_channel_count, stagedSorted/channel_count, register_aux_view, stage/register_aux_view]
         valueFrom: |

--- a/steps/inputParser.cwl
+++ b/steps/inputParser.cwl
@@ -56,6 +56,7 @@ outputs:
   clip_max: float
   level_method: string
   register_aux_view: string
+  register_to_primary: boolean
   channels_per_reg: int
   background_view: string
   register_background: boolean

--- a/steps/processing.cwl
+++ b/steps/processing.cwl
@@ -42,6 +42,10 @@ inputs:
     type: string?
     doc: The name of the auxillary view to be used for image registration.
 
+  register_to_primary:
+    type: boolean?
+    doc: If true, registration will be performed between the first round of register_aux_view and the primary images.
+
   channels_per_reg:
     type: int?
     doc: The number of images associated with each channel in the registration image.  Will be calculated from aux view if provided through parameter_json, otherwise defaults to one.
@@ -135,7 +139,7 @@ steps:
     in:
       datafile: parameter_json
       schema: read_schema/data
-    out: [selected_fovs, clip_min, clip_max, level_method, rescale, register_aux_view, channels_per_reg, background_view, register_background, anchor_view, high_sigma, deconvolve_iter, deconvolve_sigma, low_sigma, rolling_radius, match_histogram, tophat_radius, channel_count, aux_tilesets_aux_names, aux_tilesets_aux_channel_count, is_volume, n_processes]
+    out: [selected_fovs, clip_min, clip_max, level_method, rescale, register_aux_view, register_to_primary, channels_per_reg, background_view, register_background, anchor_view, high_sigma, deconvolve_iter, deconvolve_sigma, low_sigma, rolling_radius, match_histogram, tophat_radius, channel_count, aux_tilesets_aux_names, aux_tilesets_aux_channel_count, is_volume, n_processes]
     when: $(inputs.datafile != null)
 
   execute_processing:
@@ -199,6 +203,11 @@ steps:
           inputBinding:
             prefix: --register-aux-view
           doc: The name of the auxillary view to be used for image registration. Registration will not be performed if not provided.
+
+        register_to_primary:
+          type: boolean?
+          inputBinding:
+            prefix: --register-to-primary
 
         channels_per_reg:
           type: int?
@@ -354,6 +363,18 @@ steps:
           }
       register_aux_view:
         source: [stage_processing/register_aux_view, register_aux_view]
+        valueFrom: |
+          ${
+            if(self[0]){
+              return self[0];
+            } else if(self[1]) {
+              return self[1];
+            } else {
+              return null;
+            }
+          }
+      register_to_primary:
+        source: [stage_processing/register_to_primary, register_to_primary]
         valueFrom: |
           ${
             if(self[0]){


### PR DESCRIPTION
Adds ```--register_primary_view``` as a parameter option. If used and the specified aux image has only a single round, it will calculate registration shifts based on aligning each primary image with the single aux image and then apply those shifts to the primary images. ```--register_aux_view``` still does the same thing where shifts are calculated based on alignment of the aux images across rounds which are then applied to the primary images. Will throw an error if both are used as they are mutually exclusive.