### PR TITLE
Minor Changes/Fixes

### DIFF
--- a/bin/cellposeStaging.py
+++ b/bin/cellposeStaging.py
@@ -135,7 +135,7 @@ def filter_cellpose(
             mask = skimage.segmentation.relabel_sequential(mask)[0]
 
         # Save result
-        tifffile.imsave(f'{output_dir}/fov_{file.split("fov_")[-1][:3]}_masks.tiff', mask)
+        tifffile.imsave(f'{output_dir}/fov_{file.split("fov_")[-1][:5]}_masks.tiff', mask)
 
 
 if __name__ == "__main__":

--- a/bin/cellposeStaging.py
+++ b/bin/cellposeStaging.py
@@ -38,7 +38,7 @@ def cellpose_format(output_dir, input_dir, aux_ch_names, mRNA_dir, selected_fovs
             for primary_json in primary_jsons
         ]
     else:
-        fovs = ["fov_{:03}".format(int(f)) for f in selected_fovs]
+        fovs = ["fov_{:05}".format(int(f)) for f in selected_fovs]
 
     # Get number of z slices by looking at the fov_000 files
     fov0_files = glob.glob(f"{input_dir}/primary-{fovs[0]}*.tiff")

--- a/bin/imgProcessing.py
+++ b/bin/imgProcessing.py
@@ -391,7 +391,7 @@ def cli(
         str(input_dir / "experiment.json")
     )
     if selected_fovs is not None:
-        fovs = ["fov_{:03}".format(int(f)) for f in selected_fovs]
+        fovs = ["fov_{:05}".format(int(f)) for f in selected_fovs]
     else:
         fovs = list(exp.keys())
 

--- a/bin/qcDriver.py
+++ b/bin/qcDriver.py
@@ -1581,7 +1581,7 @@ if __name__ == "__main__":
     fovs = False
     if args.selected_fovs is not None:
         # manually specified FOVs override anything else
-        fovs = ["fov_{:03}".format(int(f)) for f in args.selected_fovs]
+        fovs = ["fov_{:05}".format(int(f)) for f in args.selected_fovs]
     elif args.exp_output:
         # reading in from experiment can have multiple FOVs
         fovs = [k for k in transcripts.keys()]

--- a/bin/segmentationDriver.py
+++ b/bin/segmentationDriver.py
@@ -77,7 +77,6 @@ def maskFromLabeledImages(
     """
     i = int(fov[-5:])
     label_name = ("{}/" + file_formats_labeled).format(labeled_image, i)
-    print(fov, i, labeled_image, label_name, file_formats_labeled)
     return BinaryMaskCollection.from_external_labeled_image(label_name, img)
 
 

--- a/bin/segmentationDriver.py
+++ b/bin/segmentationDriver.py
@@ -77,6 +77,7 @@ def maskFromLabeledImages(
     """
     i = int(fov[-5:])
     label_name = ("{}/" + file_formats_labeled).format(labeled_image, i)
+    print(fov, i, labeled_image, label_name, file_formats_labeled)
     return BinaryMaskCollection.from_external_labeled_image(label_name, img)
 
 

--- a/bin/segmentationDriver.py
+++ b/bin/segmentationDriver.py
@@ -48,7 +48,7 @@ def maskFromRoi(
     list[BinaryMaskCollection]:
         Binary masks for each FOV.
     """
-    i = int(fov[-3:])
+    i = int(fov[-5:])
     mask_name = ("{}/" + file_formats).format(roi_set, i)
     return BinaryMaskCollection.from_fiji_roi_set(mask_name, img)
 
@@ -75,7 +75,7 @@ def maskFromLabeledImages(
     BinaryMaskCollection:
         Binary mask.
     """
-    i = int(fov[-3:])
+    i = int(fov[-5:])
     label_name = ("{}/" + file_formats_labeled).format(labeled_image, i)
     return BinaryMaskCollection.from_external_labeled_image(label_name, img)
 

--- a/bin/segmentationDriver.py
+++ b/bin/segmentationDriver.py
@@ -632,7 +632,7 @@ def run(
 
     # IF WE'RE DOING DENSITY BASED, THAT's DIFFERENT
     if selected_fovs is not None:
-        fovs = ["fov_{:03}".format(int(f)) for f in selected_fovs]
+        fovs = ["fov_{:05}".format(int(f)) for f in selected_fovs]
     else:
         fovs = results.keys()
 

--- a/bin/spaceTxConverter.py
+++ b/bin/spaceTxConverter.py
@@ -994,8 +994,10 @@ if __name__ == "__main__":
                     "Error: blank code generation only built for one-hot codebooks (codebooks where\
                                   each round has exactly one active channel)."
                 )
-        if any(['blank' in target.lower() for target in codebook['target'].data]):
-            raise ValueError("Error: codebook already contains blank codes, set add_blanks to False.")
+        if any(["blank" in target.lower() for target in codebook["target"].data]):
+            raise ValueError(
+                "Error: codebook already contains blank codes, set add_blanks to False."
+            )
 
     cli(
         args.input_dir,

--- a/bin/spaceTxConverter.py
+++ b/bin/spaceTxConverter.py
@@ -663,7 +663,6 @@ def cli(
     print(primary_tile_fetcher)
     # print(aux_name_to_dimensions)
     # print(aux_tile_fetcher)
-
     write_experiment_json(
         path=output_dir,
         fov_count=counts["fovs"],

--- a/bin/spaceTxConverter.py
+++ b/bin/spaceTxConverter.py
@@ -990,6 +990,9 @@ if __name__ == "__main__":
                     "Error: blank code generation only built for one-hot codebooks (codebooks where\
                                   each round has exactly one active channel)."
                 )
+        if any(['blank' in target.lower() for target in codebook['target'].data]):
+            raise ValueError("Error: codebook already contains blank codes, set add_blanks to False.")
+
 
     cli(
         args.input_dir,

--- a/bin/spaceTxConverter.py
+++ b/bin/spaceTxConverter.py
@@ -981,6 +981,10 @@ if __name__ == "__main__":
 
     # If adding blanks, check that codebook is compatible before beginning conversion (otherwise it will
     # cause an error after wasting time converting images)
+    if args.codebook_csv:
+        codebook = parse_codebook(args.codebook_csv)
+    if args.codebook_json:
+        codebook = Codebook.open_json(str(args.codebook_json))
     if args.add_blanks:
         channelsN = len(codebook["c"])
         for row in codebook[0].data:

--- a/bin/spaceTxConverter.py
+++ b/bin/spaceTxConverter.py
@@ -993,7 +993,6 @@ if __name__ == "__main__":
         if any(['blank' in target.lower() for target in codebook['target'].data]):
             raise ValueError("Error: codebook already contains blank codes, set add_blanks to False.")
 
-
     cli(
         args.input_dir,
         output_dir,

--- a/bin/spaceTxConverter.py
+++ b/bin/spaceTxConverter.py
@@ -724,15 +724,6 @@ def blank_codebook(real_codebook, num_blanks):
         )
     )
 
-    # Check that codebook is one-hot
-    for row in real_codebook[0].data:
-        row_sum = sum(row == 0)
-        if row_sum == channelsN or row_sum == 0:
-            raise ValueError(
-                "Error: blank code generation only built for one-hot codebooks (codebooks where\
-                              each round has exactly one active channel)."
-            )
-
     # Calculate hamming distance rule in codebook
     codes = real_codebook.argmax(Axes.CH.value).data
     hamming_distance = 100
@@ -987,6 +978,19 @@ if __name__ == "__main__":
         "fov_offset": args.fov_offset,
         "channel_offset": args.channel_offset,
     }
+
+    # If adding blanks, check that codebook is compatible before beginning conversion (otherwise it will
+    # cause an error after wasting time converting images)
+    if args.add_blanks:
+        channelsN = len(codebook["c"])
+        for row in codebook[0].data:
+            row_sum = sum(row == 0)
+            if row_sum == channelsN or row_sum == 0:
+                raise ValueError(
+                    "Error: blank code generation only built for one-hot codebooks (codebooks where\
+                                  each round has exactly one active channel)."
+                )
+
     cli(
         args.input_dir,
         output_dir,

--- a/bin/starfishDriver.py
+++ b/bin/starfishDriver.py
@@ -568,7 +568,7 @@ def createComposite(
     for pos in range(fov_count):
         print(pos)
 
-        fov = "fov_" + "0" * (3 - len(str(pos))) + str(pos)
+        fov = "fov_" + "0" * (5 - len(str(pos))) + str(pos)
         img = experiment[fov].get_image("primary")
 
         x_min = composite_coords[pos]["x_min"]
@@ -621,7 +621,7 @@ def saveCompositeResults(spots, decoded, exploc, output_name):
 
     # Create a new SpotFindingResults object with only spots from each position and save separately
     for pos in range(len(composite_coords)):
-        fov = "fov_{:03}".format(pos)
+        fov = "fov_{:05}".format(pos)
         spot_attrs = {}
         x_min = composite_coords[pos]["x_min"]
         x_max = composite_coords[pos]["x_max"]
@@ -697,7 +697,7 @@ def saveCompositeResults(spots, decoded, exploc, output_name):
 
     # Save decoded transcripts
     for pos in composite_coords:
-        fov = "fov_" + "0" * (3 - len(str(pos))) + str(pos)
+        fov = "fov_" + "0" * (5 - len(str(pos))) + str(pos)
 
         # Subset transcripts for this FOV based on the FOV's composite coordinates
         x_min = composite_coords[pos]["x_min"]
@@ -859,7 +859,7 @@ def run(
     # Otherwise run on a per FOV basis
     else:
         if selected_fovs is not None:
-            fovs = ["fov_{:03}".format(int(f)) for f in selected_fovs]
+            fovs = ["fov_{:05}".format(int(f)) for f in selected_fovs]
         else:
             fovs = experiment.keys()
 

--- a/bin/starfishDriver.py
+++ b/bin/starfishDriver.py
@@ -464,9 +464,8 @@ def getCoords(exploc: str):
     Extracts physical coordinates of each FOV from the primary-fov_*.json files. Used in creating composite images.
     """
 
-    # Get json file names and set fov_count
+    # Get json file names
     img_jsons = sorted(glob.glob(f"{str(exploc)[:-15]}/primary-fov_*.json"))
-    fov_count = len(img_jsons)
 
     # Get x_min, x_max, y_min, and y_max values for all FOVs and keep track of the absolute x_min and y_min
     composite_coords = defaultdict(dict)
@@ -475,8 +474,9 @@ def getCoords(exploc: str):
     x_max_all = 0
     y_min_all = np.inf
     y_max_all = 0
-    for pos in range(fov_count):
-        with open(img_jsons[pos], "r") as file:
+    for img_json in range(img_jsons):
+        pos = img_json.split('/')[-1].split('_')[-1].split('.')[0]
+        with open(img_jsons, "r") as file:
             metadata = json.load(file)
 
         # Convert physical coordinates to pixel coordinates to find each FOVs place in the composite image
@@ -523,7 +523,8 @@ def getCoords(exploc: str):
         )
 
     # Subtract minimum coord values from xs and ys (ensures (0,0) is the top left corner)
-    for pos in range(fov_count):
+    for img_json in range(img_jsons):
+        pos = img_json.split('/')[-1].split('_')[-1].split('.')[0]
         composite_coords[pos]["x_min"] = composite_coords[pos]["x_min"] - x_min_all
         composite_coords[pos]["x_max"] = composite_coords[pos]["x_max"] - x_min_all
         composite_coords[pos]["y_min"] = composite_coords[pos]["y_min"] - y_min_all
@@ -564,9 +565,12 @@ def createComposite(
         (shape["r"], 1, shape["z"], int(y_max_all) + 1, int(x_max_all) + 1), dtype="float32"
     )
 
+    # Get json file names
+    img_jsons = sorted(glob.glob(f"{str(exploc)[:-15]}/primary-fov_*.json"))
+
     # Fill in image
-    for pos in range(fov_count):
-        print(pos)
+    for img_json in img_jsons:
+        pos = img_json.split('/')[-1].split('_')[-1].split('.')[0]
 
         fov = "fov_" + "0" * (5 - len(str(pos))) + str(pos)
         img = experiment[fov].get_image("primary")
@@ -612,6 +616,7 @@ def createComposite(
 
 
 def saveCompositeResults(spots, decoded, exploc, output_name):
+
     # Splits large spots object into lots of smaller ones
     spot_items = dict(spots.items())
     for rch in spot_items:
@@ -619,8 +624,12 @@ def saveCompositeResults(spots, decoded, exploc, output_name):
 
     composite_coords, physical_coords, y_max_all, x_max_all, shape = getCoords(exploc)
 
+    # Get json file names
+    img_jsons = sorted(glob.glob(f"{str(exploc)[:-15]}/primary-fov_*.json"))
+
     # Create a new SpotFindingResults object with only spots from each position and save separately
-    for pos in range(len(composite_coords)):
+    for img_json in img_jsons:
+        pos = img_json.split('/')[-1].split('_')[-1].split('.')[0]
         fov = "fov_{:05}".format(pos)
         spot_attrs = {}
         x_min = composite_coords[pos]["x_min"]

--- a/bin/starfishDriver.py
+++ b/bin/starfishDriver.py
@@ -1068,6 +1068,13 @@ if __name__ == "__main__":
             method = starfish.spots.DecodeSpots.CheckAll
         elif method == "postcodeDecode":
             method = starfish.spots.DecodeSpots.postcodeDecode
+            # Check that codebook is compatible with postcode
+            codebook = experiment.codebook
+            codebook_no_blanks = codebook[['blank' not in target.lower() for target in codebook['target'].data]]
+            if len(codebook_no_blanks) >= len(codebook['c']) ** len(codebook['r']):
+                raise Exception("PoSTcode decoder requires some unused barcode space or some blank codes in \
+                                 the codebook. If you have used 100% of the barcode space for real codes, \
+                                 then PoSTcode is not a valid decoding option.")
         else:
             raise Exception("DecodeSpots method " + str(method) + " is not a valid method.")
 

--- a/pipeline.cwl
+++ b/pipeline.cwl
@@ -610,7 +610,7 @@ steps:
 
       requirements:
         DockerRequirement:
-          dockerPull: hubmap/starfish-custom:latest
+          dockerPull: pipefish-custom:latest
 
       inputs:
         schema:
@@ -1107,7 +1107,7 @@ steps:
             if(self[5]){
               return {
                 "labeled_image": self[5],
-                "file_formats_labeled": "fov_{:03d}_masks.tiff"
+                "file_formats_labeled": "fov_{:05d}_masks.tiff"
               }
             } else {
               if(self[0]){

--- a/pipeline.cwl
+++ b/pipeline.cwl
@@ -610,7 +610,7 @@ steps:
 
       requirements:
         DockerRequirement:
-          dockerPull: pipefish-custom:latest
+          dockerPull: hubmap/starfish-custom:latest
 
       inputs:
         schema:


### PR DESCRIPTION
A few changes in this PR:
- FOV names now have 5 digits instead of 3 (increases the maximum number of allowed FOVs from 1000 to 100,000).
- Moved check for compatible codebook for adding blank codes to happen before original files are converted to spacetx format (prevents it from failing right at the end after already performing the conversion).
- Added check that barcode space is not being fully used before running postcode (causes an error if the entire barcode space is used).
- Adjusted how composite decoding reads FOVs (previously it found the number of FOVs and then when through each position using ```range(fov_count)``` but now it looks at the files that are actually there so if there is a position that is skipped it won't cause an error.
- Added support for using the ```selected_fovs``` parameter in composite decoding (#29)